### PR TITLE
fix: skip npm publishing when release credentials are missing

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -5,7 +5,7 @@
   "fixed": [],
   "linked": [],
   "access": "public",
-  "baseBranch": "main",
+  "baseBranch": "master",
   "updateInternalDependencies": "patch",
   "ignore": ["@awesome-api-skills/docs"]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      NPM_PUBLISH_ENABLED: ${{ secrets.NPM_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -23,12 +25,18 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Explain unavailable npm publishing
+        if: env.NPM_PUBLISH_ENABLED != 'true'
+        run: |
+          echo "Npm publishing is skipped because the NPM_TOKEN repository secret is not configured. Release pull requests remain enabled." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
         with:
           version: npm run version:packages
-          publish: npm run release:packages
+          # An empty publish input keeps Changesets in release-PR-only mode.
+          publish: ${{ env.NPM_PUBLISH_ENABLED == 'true' && 'npm run release:packages' || '' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,3 +56,9 @@ This project follows the [Contributor Covenant](https://www.contributor-covenant
 ## Regression checks
 
 Run `npm run typecheck`, `npm run validate:skills`, and `npm run test:snapshots` after changes. To deliberately refresh artifact snapshots after reviewing generator changes, run `npx tsx scripts/dev/dogfood.ts --update-snapshots`, then run the snapshot check again.
+
+## npm releases
+
+The release workflow prepares version pull requests on the default `master` branch. Publishing to npm requires the `NPM_TOKEN` GitHub Actions repository secret, containing an npm token with permission to publish the `@awesome-api-skills` packages.
+
+Without that secret, the workflow records that npm publishing was skipped and can still prepare release pull requests. After configuring the secret, the next release workflow run can publish unpublished package versions. Invalid or expired credentials still fail the publish step so release failures remain visible.


### PR DESCRIPTION
## Summary

<!-- Describe what skill or package changes are introduced in this PR -->

## Checklist before submitting

- [ ] I have run local validation via `npm run validate:skills` or `node scripts/dev/run-validation-v2.js` and all checks passed.
- [ ] `SKILL.md` contains verified technical patterns (correct SDK method names, current webhook events, exact auth headers).
- [ ] `metadata.json` includes `lastVerified` set to the current date (`YYYY-MM-DD`).
- [ ] Code examples under `examples/` are syntactically valid.
- [ ] All workspace tests pass via `npm test`.

## Automated PR Validation Notice

> [!NOTE]
> GitHub Actions automatically runs `packages/validator` against every modified skill in this PR. Submissions with schema errors or broken relationships will be flagged automatically by CI.
